### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/178/363/421178363.geojson
+++ b/data/421/178/363/421178363.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"GA",
     "wof:created":1459009179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2ccedd392dc80462dd3d65a9d1319b3",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421178363,
-    "wof:lastmodified":1566627211,
+    "wof:lastmodified":1582319704,
     "wof:name":"Komo Mondah",
     "wof:parent_id":85671235,
     "wof:placetype":"county",

--- a/data/421/181/245/421181245.geojson
+++ b/data/421/181/245/421181245.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"GA",
     "wof:created":1459009289,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42e479e6c7a7b2c3ef6a9abf935c4cc1",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421181245,
-    "wof:lastmodified":1566627210,
+    "wof:lastmodified":1582319703,
     "wof:name":"Bendje",
     "wof:parent_id":85671255,
     "wof:placetype":"county",

--- a/data/421/188/215/421188215.geojson
+++ b/data/421/188/215/421188215.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"GA",
     "wof:created":1459009538,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02de499b396b52871a13182aecad04bb",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421188215,
-    "wof:lastmodified":1566627210,
+    "wof:lastmodified":1582319703,
     "wof:name":"Lope",
     "wof:parent_id":85671237,
     "wof:placetype":"county",

--- a/data/421/189/661/421189661.geojson
+++ b/data/421/189/661/421189661.geojson
@@ -260,6 +260,9 @@
     },
     "wof:country":"GA",
     "wof:created":1459009632,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e67adff9ca47b17a68dab65b6859cfa7",
     "wof:hierarchy":[
         {
@@ -271,7 +274,7 @@
         }
     ],
     "wof:id":421189661,
-    "wof:lastmodified":1566627208,
+    "wof:lastmodified":1582319703,
     "wof:name":"Lambar\u00e9n\u00e9",
     "wof:parent_id":1091909431,
     "wof:placetype":"locality",

--- a/data/421/189/663/421189663.geojson
+++ b/data/421/189/663/421189663.geojson
@@ -581,6 +581,10 @@
     },
     "wof:country":"GA",
     "wof:created":1459009632,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b66c9fc0ade1d4eba8c8ed38e63584f",
     "wof:hierarchy":[
         {
@@ -592,7 +596,7 @@
         }
     ],
     "wof:id":421189663,
-    "wof:lastmodified":1566627209,
+    "wof:lastmodified":1582319703,
     "wof:name":"Libreville",
     "wof:parent_id":1091908769,
     "wof:placetype":"locality",

--- a/data/856/324/07/85632407.geojson
+++ b/data/856/324/07/85632407.geojson
@@ -975,6 +975,11 @@
     },
     "wof:country":"GA",
     "wof:country_alpha3":"GAB",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"2b04cf7ab2e9a899f1ff1821aee9265c",
     "wof:hierarchy":[
         {
@@ -989,7 +994,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626941,
+    "wof:lastmodified":1582319688,
     "wof:name":"Gabon",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/712/35/85671235.geojson
+++ b/data/856/712/35/85671235.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Estuaire Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57222f2c805f51ca916d23b392c8ae83",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626946,
+    "wof:lastmodified":1582319691,
     "wof:name":"Estuaire",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/37/85671237.geojson
+++ b/data/856/712/37/85671237.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Ogoou\u00e9-Ivindo Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ab1855297ecb2cf3ac7613b58a98618",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626948,
+    "wof:lastmodified":1582319693,
     "wof:name":"Ogoou\u00e9-Ivindo",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/41/85671241.geojson
+++ b/data/856/712/41/85671241.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Woleu-Ntem Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c385d27b39e69cb119d54de421e7e60c",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626951,
+    "wof:lastmodified":1582319694,
     "wof:name":"Woleu-Ntem",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/47/85671247.geojson
+++ b/data/856/712/47/85671247.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Moyen-Ogoou\u00e9 Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e1366bff8159ee4faba2b99bf1f5302",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626953,
+    "wof:lastmodified":1582319696,
     "wof:name":"Moyen-Ogoou\u00e9",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/49/85671249.geojson
+++ b/data/856/712/49/85671249.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Ngouni\u00e9 Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"247bbe2e3bdeb202e135546e0cf8f836",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626952,
+    "wof:lastmodified":1582319695,
     "wof:name":"Ngouni\u00e9",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/51/85671251.geojson
+++ b/data/856/712/51/85671251.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Nyanga Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ba763262a85f89ce09bf8db94bbc138",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626947,
+    "wof:lastmodified":1582319692,
     "wof:name":"Nyanga",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/55/85671255.geojson
+++ b/data/856/712/55/85671255.geojson
@@ -313,6 +313,9 @@
         "wd:id":"Q823751"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8527b209396c19c9a861dac082321f48",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626950,
+    "wof:lastmodified":1582319694,
     "wof:name":"Ogoou\u00e9-Maritime",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/57/85671257.geojson
+++ b/data/856/712/57/85671257.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Haut-Ogoou\u00e9 Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dcc144d3fb980ec10742dc7fd457075",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626945,
+    "wof:lastmodified":1582319690,
     "wof:name":"Haut-Ogoou\u00e9",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/65/85671265.geojson
+++ b/data/856/712/65/85671265.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Ogoou\u00e9-Lolo Province"
     },
     "wof:country":"GA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04f56d976ee937eb9a2e04aa4f112d8c",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566626947,
+    "wof:lastmodified":1582319692,
     "wof:name":"Ogoou\u00e9-Lolo",
     "wof:parent_id":85632407,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.