### PR TITLE
ga concordances, placetype local, and more

### DIFF
--- a/data/109/190/876/9/1091908769.geojson
+++ b/data/109/190/876/9/1091908769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013315,
-    "geom:area_square_m":164637899.249201,
+    "geom:area_square_m":164637898.987047,
     "geom:bbox":"9.367466,0.341596,9.527352,0.563814",
     "geom:latitude":0.450835,
     "geom:longitude":9.449909,
@@ -104,9 +104,10 @@
         "hasc:id":"GA.ES.KM",
         "wd:id":"Q2736052"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892504,
-    "wof:geomhash":"42712aba9d6fdc0cbd27759b03c0c059",
+    "wof:geomhash":"a64cf02b4b5ebc2f32610bdc25ec81b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091908769,
-    "wof:lastmodified":1690914928,
+    "wof:lastmodified":1695886254,
     "wof:name":"Libreville",
     "wof:parent_id":85671235,
     "wof:placetype":"county",

--- a/data/109/190/882/3/1091908823.geojson
+++ b/data/109/190/882/3/1091908823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.806585,
-    "geom:area_square_m":9973385046.289722,
+    "geom:area_square_m":9973385045.600792,
     "geom:bbox":"9.757244,-0.424821,10.97361,0.817087",
     "geom:latitude":0.230581,
     "geom:longitude":10.307718,
@@ -115,9 +115,10 @@
         "hasc:id":"GA.ES.KO",
         "wd:id":"Q2575582"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892506,
-    "wof:geomhash":"7a587051f869d03acca690aa9ad87129",
+    "wof:geomhash":"3412af939760e2b4d9c4e1d894f251b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091908823,
-    "wof:lastmodified":1690914927,
+    "wof:lastmodified":1695886254,
     "wof:name":"Komo",
     "wof:parent_id":85671235,
     "wof:placetype":"county",

--- a/data/109/190/886/9/1091908869.geojson
+++ b/data/109/190/886/9/1091908869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.321613,
-    "geom:area_square_m":3976407017.527348,
+    "geom:area_square_m":3976407017.2093,
     "geom:bbox":"9.551509,0.464594,10.445363,1.060003",
     "geom:latitude":0.797204,
     "geom:longitude":9.976012,
@@ -106,9 +106,10 @@
         "hasc:id":"GA.ES.NY",
         "wd:id":"Q2575614"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892508,
-    "wof:geomhash":"f9bb2f6897f19117cbd587e071f797ce",
+    "wof:geomhash":"487b0bcb8279a9600e2c9a92770be435",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091908869,
-    "wof:lastmodified":1690914922,
+    "wof:lastmodified":1695886250,
     "wof:name":"Noya",
     "wof:parent_id":85671235,
     "wof:placetype":"county",

--- a/data/109/190/891/9/1091908919.geojson
+++ b/data/109/190/891/9/1091908919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.398832,
-    "geom:area_square_m":4929240387.632255,
+    "geom:area_square_m":4929240386.649794,
     "geom:bbox":"13.277551,-2.44468,14.072901,-1.15139",
     "geom:latitude":-1.761957,
     "geom:longitude":13.648872,
@@ -110,9 +110,10 @@
         "hasc:id":"GA.HO.MP",
         "wd:id":"Q1451541"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892510,
-    "wof:geomhash":"ab75d3af61f98b232e7e38d842521fdc",
+    "wof:geomhash":"b42b5a050817856156592478268c439f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091908919,
-    "wof:lastmodified":1690914929,
+    "wof:lastmodified":1695886255,
     "wof:name":"Mpassa",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/896/7/1091908967.geojson
+++ b/data/109/190/896/7/1091908967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211343,
-    "geom:area_square_m":2612380258.435006,
+    "geom:area_square_m":2612380258.327055,
     "geom:bbox":"12.799991,-1.794547,13.408947,-1.118954",
     "geom:latitude":-1.508632,
     "geom:longitude":13.157027,
@@ -111,9 +111,10 @@
         "hasc:id":"GA.HO.LL",
         "wd:id":"Q1451513"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892511,
-    "wof:geomhash":"eeb4530e41441e9e4278c9c10088127b",
+    "wof:geomhash":"9630631d9f783d4555f7c770c6516aeb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091908967,
-    "wof:lastmodified":1690914928,
+    "wof:lastmodified":1695886255,
     "wof:name":"Lebombi Leyou",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/901/7/1091909017.geojson
+++ b/data/109/190/901/7/1091909017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319922,
-    "geom:area_square_m":3953467546.234041,
+    "geom:area_square_m":3953467546.487453,
     "geom:bbox":"12.749253,-2.377945,13.47453,-1.650586",
     "geom:latitude":-2.003252,
     "geom:longitude":13.116212,
@@ -107,9 +107,10 @@
         "hasc:id":"GA.HO.LE",
         "wd:id":"Q1451303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892513,
-    "wof:geomhash":"39399946dd696fd16d1da398b8e0ebc0",
+    "wof:geomhash":"a633595756d92ee39e455a4534e53a2b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091909017,
-    "wof:lastmodified":1690914920,
+    "wof:lastmodified":1695886248,
     "wof:name":"Lekoko",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/906/5/1091909065.geojson
+++ b/data/109/190/906/5/1091909065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128766,
-    "geom:area_square_m":1591048281.362952,
+    "geom:area_square_m":1591048281.111593,
     "geom:bbox":"13.274373,-2.436543,13.762344,-1.934471",
     "geom:latitude":-2.198305,
     "geom:longitude":13.535304,
@@ -108,9 +108,10 @@
         "hasc:id":"GA.HO.OT",
         "wd:id":"Q1451303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892515,
-    "wof:geomhash":"7161b096f7e60b939820f89083c0bbc0",
+    "wof:geomhash":"1f7b56286a9825220df7b26db458b44d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1091909065,
-    "wof:lastmodified":1690914921,
+    "wof:lastmodified":1695886249,
     "wof:name":"Ogooue Letili",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/910/1/1091909101.geojson
+++ b/data/109/190/910/1/1091909101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1763,
-    "geom:area_square_m":2179215711.092076,
+    "geom:area_square_m":2179215711.052093,
     "geom:bbox":"13.74898,-1.788022,14.305316,-1.185977",
     "geom:latitude":-1.511248,
     "geom:longitude":13.993632,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GA.HO.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892517,
-    "wof:geomhash":"b644948e2bec0429d52f91f93dbf9a22",
+    "wof:geomhash":"30999f71f34422ce9ed643ccdfd1b245",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091909101,
-    "wof:lastmodified":1627522136,
+    "wof:lastmodified":1695886618,
     "wof:name":"Djouori Agnili",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/914/9/1091909149.geojson
+++ b/data/109/190/914/9/1091909149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.441801,
-    "geom:area_square_m":5460441194.012054,
+    "geom:area_square_m":5460441194.159832,
     "geom:bbox":"13.832365,-2.51161,14.522491,-1.00976",
     "geom:latitude":-1.692363,
     "geom:longitude":14.220564,
@@ -118,9 +118,10 @@
         "hasc:id":"GA.HO.PX",
         "wd:id":"Q2355542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892518,
-    "wof:geomhash":"afef529a380fa8efcf67fca4e55bd22e",
+    "wof:geomhash":"7ec82148fe0259c35da0e2d78ac423a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091909149,
-    "wof:lastmodified":1690914925,
+    "wof:lastmodified":1695886706,
     "wof:name":"Plateaux",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/920/1/1091909201.geojson
+++ b/data/109/190/920/1/1091909201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1809,
-    "geom:area_square_m":2236643615.831761,
+    "geom:area_square_m":2236643615.330099,
     "geom:bbox":"13.98231,-1.105156,14.52902,-0.460692",
     "geom:latitude":-0.8027,
     "geom:longitude":14.292854,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GA.HO.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892520,
-    "wof:geomhash":"c136e9a2df99040210fd6a642fec8f89",
+    "wof:geomhash":"57ea2d003a6ac949f098826a34e2e1a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091909201,
-    "wof:lastmodified":1627522135,
+    "wof:lastmodified":1695886618,
     "wof:name":"Djoue",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/924/3/1091909243.geojson
+++ b/data/109/190/924/3/1091909243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107387,
-    "geom:area_square_m":1327618821.531143,
+    "geom:area_square_m":1327618821.676876,
     "geom:bbox":"13.632487,-1.267827,14.127984,-0.891542",
     "geom:latitude":-1.085234,
     "geom:longitude":13.893536,
@@ -105,9 +105,10 @@
         "hasc:id":"GA.HO.LN",
         "wd:id":"Q2349485"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892521,
-    "wof:geomhash":"1d21bafb1d1dc74b8481151fa9d02f76",
+    "wof:geomhash":"bdca5a37ef15264a780718339651ed9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091909243,
-    "wof:lastmodified":1690914924,
+    "wof:lastmodified":1695886252,
     "wof:name":"Lekoni Lekori",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/929/3/1091909293.geojson
+++ b/data/109/190/929/3/1091909293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.602198,
-    "geom:area_square_m":7445882451.442159,
+    "geom:area_square_m":7445882451.433031,
     "geom:bbox":"13.2198,-1.193799,14.179087,0.049898",
     "geom:latitude":-0.504569,
     "geom:longitude":13.653479,
@@ -89,9 +89,10 @@
         "hasc:id":"GA.HO.SB",
         "wd:id":"Q1451522"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892523,
-    "wof:geomhash":"5e6ccd424c930310dcd04df552e2f99b",
+    "wof:geomhash":"32a914d816f27f44b62242b64c03c60c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091909293,
-    "wof:lastmodified":1690914929,
+    "wof:lastmodified":1695886256,
     "wof:name":"Sebe Brikolo",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/934/7/1091909347.geojson
+++ b/data/109/190/934/7/1091909347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090309,
-    "geom:area_square_m":1116365850.151102,
+    "geom:area_square_m":1116365851.232476,
     "geom:bbox":"13.582596,-1.590023,13.866483,-1.112273",
     "geom:latitude":-1.362063,
     "geom:longitude":13.728337,
@@ -105,9 +105,10 @@
         "hasc:id":"GA.HO.LV",
         "wd:id":"Q2349485"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892525,
-    "wof:geomhash":"1459474b88e66bb042220c7b8eb21a0d",
+    "wof:geomhash":"55157064500f64fdf559545d0efca033",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091909347,
-    "wof:lastmodified":1690914927,
+    "wof:lastmodified":1695886254,
     "wof:name":"Lekabi Lewolo",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/938/9/1091909389.geojson
+++ b/data/109/190/938/9/1091909389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126645,
-    "geom:area_square_m":1565897497.29265,
+    "geom:area_square_m":1565897497.344584,
     "geom:bbox":"13.816644,-0.824405,14.364288,-0.357405",
     "geom:latitude":-0.592308,
     "geom:longitude":14.082862,
@@ -89,9 +89,10 @@
         "hasc:id":"GA.HO.SB",
         "wd:id":"Q1451522"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892526,
-    "wof:geomhash":"e059f401af83c5651b79beebd113950a",
+    "wof:geomhash":"260db890f1b6da4bfd3bce5b400d60ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091909389,
-    "wof:lastmodified":1690914919,
+    "wof:lastmodified":1695886247,
     "wof:name":"Bayi Brikolo",
     "wof:parent_id":85671257,
     "wof:placetype":"county",

--- a/data/109/190/943/1/1091909431.geojson
+++ b/data/109/190/943/1/1091909431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.7374,
-    "geom:area_square_m":9117370898.384319,
+    "geom:area_square_m":9117370897.85256,
     "geom:bbox":"9.549501,-1.263525,10.921146,-0.198808",
     "geom:latitude":-0.687331,
     "geom:longitude":10.15582,
@@ -111,9 +111,10 @@
         "hasc:id":"GA.MO.OL",
         "wd:id":"Q3881247"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892528,
-    "wof:geomhash":"b2f1034bba99eaf28ff3291c90d65429",
+    "wof:geomhash":"db938814118448982c0a28369e7c5ecf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091909431,
-    "wof:lastmodified":1690914931,
+    "wof:lastmodified":1695886258,
     "wof:name":"Ogooue Et Lacs",
     "wof:parent_id":85671247,
     "wof:placetype":"county",

--- a/data/109/190/948/7/1091909487.geojson
+++ b/data/109/190/948/7/1091909487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.652392,
-    "geom:area_square_m":8066851221.897101,
+    "geom:area_square_m":8066851222.040161,
     "geom:bbox":"10.366651,-0.761655,11.587622,0.268815",
     "geom:latitude":-0.164518,
     "geom:longitude":10.992752,
@@ -116,9 +116,10 @@
         "hasc:id":"GA.MO.AB",
         "wd:id":"Q3603126"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892530,
-    "wof:geomhash":"267cbb11bef5fbbd28498dfe10cba723",
+    "wof:geomhash":"ac2f6437ae45ce4e1c875e844a0d1e83",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1091909487,
-    "wof:lastmodified":1690914922,
+    "wof:lastmodified":1695886250,
     "wof:name":"Abanga Bigne",
     "wof:parent_id":85671247,
     "wof:placetype":"county",

--- a/data/109/190/953/1/1091909531.geojson
+++ b/data/109/190/953/1/1091909531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.205091,
-    "geom:area_square_m":2534861885.876085,
+    "geom:area_square_m":2534861885.930093,
     "geom:bbox":"10.755151,-2.094089,11.325473,-1.212718",
     "geom:latitude":-1.696694,
     "geom:longitude":11.05429,
@@ -110,9 +110,10 @@
         "hasc:id":"GA.NG.DY",
         "wd:id":"Q1451295"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892531,
-    "wof:geomhash":"bc116870a94824dc50f52445c4beb138",
+    "wof:geomhash":"828d0be54cd80a238b76e39f12b749bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091909531,
-    "wof:lastmodified":1690914919,
+    "wof:lastmodified":1695886248,
     "wof:name":"Douya Onoye",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/958/1/1091909581.geojson
+++ b/data/109/190/958/1/1091909581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.814911,
-    "geom:area_square_m":10074359866.524656,
+    "geom:area_square_m":10074359866.127237,
     "geom:bbox":"10.348929,-1.878531,11.244788,-0.383347",
     "geom:latitude":-1.133954,
     "geom:longitude":10.814742,
@@ -107,9 +107,10 @@
         "hasc:id":"GA.NG.TM",
         "wd:id":"Q1451531"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892533,
-    "wof:geomhash":"dd5a9129953d6580b482c1e52c83fb05",
+    "wof:geomhash":"a16ca5849c50571552481f3d05183114",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091909581,
-    "wof:lastmodified":1690914926,
+    "wof:lastmodified":1695886252,
     "wof:name":"Tsamba Magotsi",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/963/5/1091909635.geojson
+++ b/data/109/190/963/5/1091909635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.386313,
-    "geom:area_square_m":4774942401.230947,
+    "geom:area_square_m":4774942401.803207,
     "geom:bbox":"9.859258,-2.107475,10.623516,-1.13603",
     "geom:latitude":-1.59814,
     "geom:longitude":10.246341,
@@ -106,9 +106,10 @@
         "hasc:id":"GA.NG.NL",
         "wd:id":"Q1451290"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892535,
-    "wof:geomhash":"23e99f78ca0c6456e8ae28efd72e2f80",
+    "wof:geomhash":"6686b3bdf1c848b35ac45c4dc6d0648f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091909635,
-    "wof:lastmodified":1690914921,
+    "wof:lastmodified":1695886250,
     "wof:name":"Ndolou",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/966/3/1091909663.geojson
+++ b/data/109/190/966/3/1091909663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207562,
-    "geom:area_square_m":2564844530.60784,
+    "geom:area_square_m":2564844529.920353,
     "geom:bbox":"10.489691,-2.336248,11.057662,-1.76691",
     "geom:latitude":-2.082999,
     "geom:longitude":10.780614,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GA.NG.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892537,
-    "wof:geomhash":"01523d6558aa7812591517d83b7adbba",
+    "wof:geomhash":"015194774abd2590bbe4e797c50f70f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091909663,
-    "wof:lastmodified":1627522136,
+    "wof:lastmodified":1695886619,
     "wof:name":"Mougalaba",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/970/7/1091909707.geojson
+++ b/data/109/190/970/7/1091909707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215257,
-    "geom:area_square_m":2659454412.580708,
+    "geom:area_square_m":2659454412.182253,
     "geom:bbox":"10.984912,-2.722092,11.605838,-2.003768",
     "geom:latitude":-2.347533,
     "geom:longitude":11.310232,
@@ -109,9 +109,10 @@
         "hasc:id":"GA.NG.DL",
         "wd:id":"Q2322977"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892539,
-    "wof:geomhash":"ca4ea838aa199d6b754e642e0f59254e",
+    "wof:geomhash":"f7d627950882ba5b232d583e0c7f681e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091909707,
-    "wof:lastmodified":1690914924,
+    "wof:lastmodified":1695886251,
     "wof:name":"Dola",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/975/7/1091909757.geojson
+++ b/data/109/190/975/7/1091909757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072326,
-    "geom:area_square_m":893673284.841177,
+    "geom:area_square_m":893673284.883115,
     "geom:bbox":"11.348146,-2.413158,11.694027,-1.95299",
     "geom:latitude":-2.191307,
     "geom:longitude":11.528461,
@@ -106,9 +106,10 @@
         "hasc:id":"GA.NG.LW",
         "wd:id":"Q1451560"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892540,
-    "wof:geomhash":"d36c8a55a7f2e3dc03a48b6b319b8545",
+    "wof:geomhash":"0fd06533fedb3dccad513dcc35887ccd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091909757,
-    "wof:lastmodified":1690914932,
+    "wof:lastmodified":1695886259,
     "wof:name":"Louetsi Wano",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/978/7/1091909787.geojson
+++ b/data/109/190/978/7/1091909787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.305994,
-    "geom:area_square_m":3780822339.002607,
+    "geom:area_square_m":3780822339.721364,
     "geom:bbox":"11.888769,-2.525048,12.518097,-1.780059",
     "geom:latitude":-2.21823,
     "geom:longitude":12.23446,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GA.NG.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892542,
-    "wof:geomhash":"29dba523a2186fa0edc0b6f26c99655a",
+    "wof:geomhash":"aebe9c5e056b4fed2658bbb7cb268948",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091909787,
-    "wof:lastmodified":1627522136,
+    "wof:lastmodified":1695886619,
     "wof:name":"Louetsi Bibaka",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/983/3/1091909833.geojson
+++ b/data/109/190/983/3/1091909833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317104,
-    "geom:area_square_m":3918590431.815189,
+    "geom:area_square_m":3918590431.851049,
     "geom:bbox":"11.505648,-2.550741,12.237936,-1.631015",
     "geom:latitude":-2.019201,
     "geom:longitude":11.847817,
@@ -101,9 +101,10 @@
         "hasc:id":"GA.NG.BM",
         "wd:id":"Q1451317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892543,
-    "wof:geomhash":"c2829f5014f1f639081937e14f23392b",
+    "wof:geomhash":"7e20b7c9d32cd45b4b7a44fa37ec5221",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091909833,
-    "wof:lastmodified":1690914923,
+    "wof:lastmodified":1695886251,
     "wof:name":"Boumi Louetsi",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/988/7/1091909887.geojson
+++ b/data/109/190/988/7/1091909887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.658932,
-    "geom:area_square_m":8145279243.997789,
+    "geom:area_square_m":8145279243.9028,
     "geom:bbox":"11.119857,-2.097103,11.973565,-0.611201",
     "geom:latitude":-1.392859,
     "geom:longitude":11.488598,
@@ -106,9 +106,10 @@
         "hasc:id":"GA.NG.OU",
         "wd:id":"Q1451274"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892545,
-    "wof:geomhash":"311e5dc1689fbe8841c6db1bd2dc524e",
+    "wof:geomhash":"ab0875c4b948b35978f05465fb8bc169",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091909887,
-    "wof:lastmodified":1690914930,
+    "wof:lastmodified":1695886257,
     "wof:name":"Ogoulou",
     "wof:parent_id":85671249,
     "wof:placetype":"county",

--- a/data/109/190/993/1/1091909931.geojson
+++ b/data/109/190/993/1/1091909931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252832,
-    "geom:area_square_m":3122577363.747729,
+    "geom:area_square_m":3122577363.704688,
     "geom:bbox":"10.546055,-3.114065,11.309919,-2.335938",
     "geom:latitude":-2.799148,
     "geom:longitude":10.90019,
@@ -106,9 +106,10 @@
         "hasc:id":"GA.NY.MT",
         "wd:id":"Q1452160"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892547,
-    "wof:geomhash":"736a795135822955ff2aa5e269807d38",
+    "wof:geomhash":"ba055b5d2660e5f2c4e4a02efb479e9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091909931,
-    "wof:lastmodified":1690914925,
+    "wof:lastmodified":1695886253,
     "wof:name":"Mougoutsi",
     "wof:parent_id":85671251,
     "wof:placetype":"county",

--- a/data/109/190/996/9/1091909969.geojson
+++ b/data/109/190/996/9/1091909969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.274467,
-    "geom:area_square_m":3388416457.496136,
+    "geom:area_square_m":3388416457.761937,
     "geom:bbox":"10.256784,-3.62253,11.13556,-2.82566",
     "geom:latitude":-3.234074,
     "geom:longitude":10.749558,
@@ -98,9 +98,10 @@
         "hasc:id":"GA.NY.BB",
         "wd:id":"Q1451282"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892549,
-    "wof:geomhash":"0c4f37fc3bdc9c200e4b66d7777f43f7",
+    "wof:geomhash":"108027f33102f19d2e793111b17278eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091909969,
-    "wof:lastmodified":1690914920,
+    "wof:lastmodified":1695886249,
     "wof:name":"Basse Banio",
     "wof:parent_id":85671251,
     "wof:placetype":"county",

--- a/data/109/191/001/9/1091910019.geojson
+++ b/data/109/191/001/9/1091910019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125482,
-    "geom:area_square_m":1548431182.279668,
+    "geom:area_square_m":1548431181.677001,
     "geom:bbox":"10.876088,-3.963731,11.336516,-3.378041",
     "geom:latitude":-3.664264,
     "geom:longitude":11.119931,
@@ -98,9 +98,10 @@
         "hasc:id":"GA.NY.BB",
         "wd:id":"Q1452184"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892550,
-    "wof:geomhash":"e2536cdeaf7b7676e14991356e68caa7",
+    "wof:geomhash":"56e645f5917722710ac52bd04fda44d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091910019,
-    "wof:lastmodified":1690914911,
+    "wof:lastmodified":1695886239,
     "wof:name":"Haute Banio",
     "wof:parent_id":85671251,
     "wof:placetype":"county",

--- a/data/109/191/004/7/1091910047.geojson
+++ b/data/109/191/004/7/1091910047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186813,
-    "geom:area_square_m":2307831275.699713,
+    "geom:area_square_m":2307831276.020079,
     "geom:bbox":"10.556554,-2.74797,11.235582,-2.235291",
     "geom:latitude":-2.468467,
     "geom:longitude":10.88602,
@@ -98,9 +98,10 @@
         "hasc:id":"GA.NY.DG",
         "wd:id":"Q284548"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892552,
-    "wof:geomhash":"93eab8b5dfdb50751115fd5dedd600eb",
+    "wof:geomhash":"80d3c9e8f5cdf79c620df58589d74365",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091910047,
-    "wof:lastmodified":1690914915,
+    "wof:lastmodified":1695886243,
     "wof:name":"Douigni",
     "wof:parent_id":85671251,
     "wof:placetype":"county",

--- a/data/109/191/008/3/1091910083.geojson
+++ b/data/109/191/008/3/1091910083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230514,
-    "geom:area_square_m":2846640862.457705,
+    "geom:area_square_m":2846640863.344535,
     "geom:bbox":"11.132776,-3.32184,12.031679,-2.544019",
     "geom:latitude":-2.919589,
     "geom:longitude":11.620548,
@@ -109,9 +109,10 @@
         "hasc:id":"GA.NY.DT",
         "wd:id":"Q1452160"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892553,
-    "wof:geomhash":"a7573961cffff5e707483f02162c667f",
+    "wof:geomhash":"62f23c662dea3ba5d0056a24adaa687a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091910083,
-    "wof:lastmodified":1690914911,
+    "wof:lastmodified":1695886239,
     "wof:name":"Doutsila",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/191/012/9/1091910129.geojson
+++ b/data/109/191/012/9/1091910129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.496373,
-    "geom:area_square_m":6127642138.045703,
+    "geom:area_square_m":6127642138.915755,
     "geom:bbox":"10.810268,-3.736283,12.008821,-2.848813",
     "geom:latitude":-3.281903,
     "geom:longitude":11.455969,
@@ -110,9 +110,10 @@
         "hasc:id":"GA.NY.MN",
         "wd:id":"Q1452160"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892555,
-    "wof:geomhash":"ec131f166498b9351acec57c9e79ef48",
+    "wof:geomhash":"fa3cb7e03dbdf106d4dd1eb66dffe31d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091910129,
-    "wof:lastmodified":1690914908,
+    "wof:lastmodified":1695886706,
     "wof:name":"Mongo",
     "wof:parent_id":85671251,
     "wof:placetype":"county",

--- a/data/109/191/016/9/1091910169.geojson
+++ b/data/109/191/016/9/1091910169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.459338,
-    "geom:area_square_m":18043430120.316654,
+    "geom:area_square_m":18043430119.891537,
     "geom:bbox":"12.163019,-0.103339,13.946317,1.36805",
     "geom:latitude":0.669432,
     "geom:longitude":13.046495,
@@ -115,9 +115,10 @@
         "hasc:id":"GA.OI.IV",
         "wd:id":"Q1452145"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892556,
-    "wof:geomhash":"1129229548cc1b35ea8b96cbb3d5e997",
+    "wof:geomhash":"759865ea202fad2fbd7691695a08bf12",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091910169,
-    "wof:lastmodified":1690914914,
+    "wof:lastmodified":1695886707,
     "wof:name":"Ivindo",
     "wof:parent_id":85671237,
     "wof:placetype":"county",

--- a/data/109/191/021/9/1091910219.geojson
+++ b/data/109/191/021/9/1091910219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.793018,
-    "geom:area_square_m":9804533987.114473,
+    "geom:area_square_m":9804533987.06673,
     "geom:bbox":"13.390184,0.278993,14.529043,1.437618",
     "geom:latitude":0.889711,
     "geom:longitude":13.957785,
@@ -101,9 +101,10 @@
         "hasc:id":"GA.OI.ZA",
         "wd:id":"Q1452114"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892558,
-    "wof:geomhash":"a6b9359f1639d92c9ba9932b82fc6b6d",
+    "wof:geomhash":"26c13229ffcf1d2545daac9f6f463784",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091910219,
-    "wof:lastmodified":1690914915,
+    "wof:lastmodified":1695886242,
     "wof:name":"Zadie",
     "wof:parent_id":85671237,
     "wof:placetype":"county",

--- a/data/109/191/027/1/1091910271.geojson
+++ b/data/109/191/027/1/1091910271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.344297,
-    "geom:area_square_m":4257185150.368948,
+    "geom:area_square_m":4257185150.497172,
     "geom:bbox":"11.851944,-0.000243,12.588629,0.851717",
     "geom:latitude":0.367092,
     "geom:longitude":12.161454,
@@ -100,9 +100,10 @@
         "hasc:id":"GA.OI.MV",
         "wd:id":"Q1604719"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892560,
-    "wof:geomhash":"0cb8faeea86bafcdcbd1f36911d1b151",
+    "wof:geomhash":"da641582c1086586105240b69770d6ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091910271,
-    "wof:lastmodified":1690914913,
+    "wof:lastmodified":1695886241,
     "wof:name":"Mvoung",
     "wof:parent_id":85671237,
     "wof:placetype":"county",

--- a/data/109/191/031/3/1091910313.geojson
+++ b/data/109/191/031/3/1091910313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.635261,
-    "geom:area_square_m":7853321256.545047,
+    "geom:area_square_m":7853321257.94901,
     "geom:bbox":"11.859825,-1.914394,12.854564,-0.507893",
     "geom:latitude":-1.175953,
     "geom:longitude":12.324654,
@@ -107,9 +107,10 @@
         "hasc:id":"GA.OL.LG",
         "wd:id":"Q1452171"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892562,
-    "wof:geomhash":"55f9ea8a068a80462f7e695d1f80b4e2",
+    "wof:geomhash":"6b87692a973518b644871042a09d0244",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091910313,
-    "wof:lastmodified":1690914910,
+    "wof:lastmodified":1695886238,
     "wof:name":"Lolo Bouenguidi",
     "wof:parent_id":85671265,
     "wof:placetype":"county",

--- a/data/109/191/035/9/1091910359.geojson
+++ b/data/109/191/035/9/1091910359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138089,
-    "geom:area_square_m":1706825463.344919,
+    "geom:area_square_m":1706825462.390046,
     "geom:bbox":"12.431362,-1.926016,12.857159,-1.373158",
     "geom:latitude":-1.601927,
     "geom:longitude":12.659326,
@@ -97,9 +97,10 @@
         "hasc:id":"GA.OL.LB",
         "wd:id":"Q940175"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892564,
-    "wof:geomhash":"40297104eae0b1985bfdd6768537d6d5",
+    "wof:geomhash":"be5481052e3b4ae8639a0020595e13f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091910359,
-    "wof:lastmodified":1690914916,
+    "wof:lastmodified":1695886243,
     "wof:name":"Lombo-Bouenguidi (Pana)",
     "wof:parent_id":85671265,
     "wof:placetype":"county",

--- a/data/109/191/040/9/1091910409.geojson
+++ b/data/109/191/040/9/1091910409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330906,
-    "geom:area_square_m":4090951683.418832,
+    "geom:area_square_m":4090951682.737367,
     "geom:bbox":"11.497167,-1.647417,12.200464,-0.658661",
     "geom:latitude":-1.081947,
     "geom:longitude":11.868188,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GA.OL.OO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892565,
-    "wof:geomhash":"9cca22e036d3dac06d7a20689d5f1291",
+    "wof:geomhash":"913f8297f1290fa90d9c8a73b57fdbf7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091910409,
-    "wof:lastmodified":1627522136,
+    "wof:lastmodified":1695886619,
     "wof:name":"Offoue Onoye",
     "wof:parent_id":85671265,
     "wof:placetype":"county",

--- a/data/109/191/045/5/1091910455.geojson
+++ b/data/109/191/045/5/1091910455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.270601,
-    "geom:area_square_m":15710039679.48498,
+    "geom:area_square_m":15710039679.693001,
     "geom:bbox":"12.286282,-1.690897,13.56558,0.314384",
     "geom:latitude":-0.571511,
     "geom:longitude":12.937029,
@@ -107,9 +107,10 @@
         "hasc:id":"GA.OL.ML",
         "wd:id":"Q2322355"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892567,
-    "wof:geomhash":"5ec906b6461faad9085d85d06aea2047",
+    "wof:geomhash":"4192c7f5042b03c230c22468dded9a98",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091910455,
-    "wof:lastmodified":1690914912,
+    "wof:lastmodified":1695886240,
     "wof:name":"Mouloundou",
     "wof:parent_id":85671265,
     "wof:placetype":"county",

--- a/data/109/191/050/9/1091910509.geojson
+++ b/data/109/191/050/9/1091910509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.698693,
-    "geom:area_square_m":8635856692.129396,
+    "geom:area_square_m":8635856692.16798,
     "geom:bbox":"8.854078,-2.251083,10.099134,-1.007337",
     "geom:latitude":-1.634166,
     "geom:longitude":9.557157,
@@ -111,9 +111,10 @@
         "hasc:id":"GA.OM.ET",
         "wd:id":"Q610846"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892569,
-    "wof:geomhash":"cba270d986093cf7265fa15309f1d27b",
+    "wof:geomhash":"a1d4ae50802a217a01b5f0df56571c8f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091910509,
-    "wof:lastmodified":1690914917,
+    "wof:lastmodified":1695886244,
     "wof:name":"Etimboue",
     "wof:parent_id":85671255,
     "wof:placetype":"county",

--- a/data/109/191/056/3/1091910563.geojson
+++ b/data/109/191/056/3/1091910563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.712794,
-    "geom:area_square_m":8805886781.756388,
+    "geom:area_square_m":8805886780.629366,
     "geom:bbox":"9.585206,-3.012308,10.601212,-1.856176",
     "geom:latitude":-2.418972,
     "geom:longitude":10.165799,
@@ -106,9 +106,10 @@
         "hasc:id":"GA.OM.NG",
         "wd:id":"Q2322391"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892571,
-    "wof:geomhash":"15fa3cb4f75c7510e1831bcb119995ae",
+    "wof:geomhash":"000279b439a246cc80dafa9ab7ae8766",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091910563,
-    "wof:lastmodified":1690914918,
+    "wof:lastmodified":1695886247,
     "wof:name":"Ndougou",
     "wof:parent_id":85671255,
     "wof:placetype":"county",

--- a/data/109/191/059/3/1091910593.geojson
+++ b/data/109/191/059/3/1091910593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.695186,
-    "geom:area_square_m":8593422606.087585,
+    "geom:area_square_m":8593422610.162613,
     "geom:bbox":"11.327214,0.944076,12.493958,1.889926",
     "geom:latitude":1.418941,
     "geom:longitude":11.785513,
@@ -97,9 +97,10 @@
         "hasc:id":"GA.WN.WO",
         "wd:id":"Q2322921"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892573,
-    "wof:geomhash":"1b3c1e97c028842afd8bf4c5ab9b6854",
+    "wof:geomhash":"c188305ee5874ffebcc6ad9ba706e84a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091910593,
-    "wof:lastmodified":1690914916,
+    "wof:lastmodified":1695886245,
     "wof:name":"Woleu",
     "wof:parent_id":85671241,
     "wof:placetype":"county",

--- a/data/109/191/063/9/1091910639.geojson
+++ b/data/109/191/063/9/1091910639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190346,
-    "geom:area_square_m":2352096562.782144,
+    "geom:area_square_m":2352096562.00045,
     "geom:bbox":"11.326153,1.833303,11.851222,2.318188",
     "geom:latitude":2.092345,
     "geom:longitude":11.570191,
@@ -97,9 +97,10 @@
         "hasc:id":"GA.WN.NT",
         "wd:id":"Q2322933"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892574,
-    "wof:geomhash":"5ac4ce168d532ee4a908b964fce4f87f",
+    "wof:geomhash":"6d74815b43fc2c640f76af2c566275cb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091910639,
-    "wof:lastmodified":1690914910,
+    "wof:lastmodified":1695886240,
     "wof:name":"Ntem",
     "wof:parent_id":85671241,
     "wof:placetype":"county",

--- a/data/109/191/068/9/1091910689.geojson
+++ b/data/109/191/068/9/1091910689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.221227,
-    "geom:area_square_m":15092937721.122269,
+    "geom:area_square_m":15092937721.465872,
     "geom:bbox":"11.705851,1.216594,13.305719,2.295163",
     "geom:latitude":1.816814,
     "geom:longitude":12.57689,
@@ -100,9 +100,10 @@
         "hasc:id":"GA.WN.HN",
         "wd:id":"Q2322373"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892576,
-    "wof:geomhash":"b55d7c5d952e770ea9e492c8bd99e0fc",
+    "wof:geomhash":"6930fec544c7146d43ff392b4f02194b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091910689,
-    "wof:lastmodified":1690914917,
+    "wof:lastmodified":1695886246,
     "wof:name":"Haut Ntem",
     "wof:parent_id":85671241,
     "wof:placetype":"county",

--- a/data/109/191/073/3/1091910733.geojson
+++ b/data/109/191/073/3/1091910733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.801275,
-    "geom:area_square_m":9907081709.744772,
+    "geom:area_square_m":9907081704.721848,
     "geom:bbox":"10.813517,0.219184,12.357982,1.246498",
     "geom:latitude":0.705472,
     "geom:longitude":11.484983,
@@ -97,9 +97,10 @@
         "hasc:id":"GA.WN.OK",
         "wd:id":"Q522580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892577,
-    "wof:geomhash":"76611a4880bc42868c2870c8cf2d11c6",
+    "wof:geomhash":"223c095c7eca9e19348d08b41d61a4b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091910733,
-    "wof:lastmodified":1690914912,
+    "wof:lastmodified":1695886241,
     "wof:name":"Okano",
     "wof:parent_id":85671241,
     "wof:placetype":"county",

--- a/data/109/191/078/3/1091910783.geojson
+++ b/data/109/191/078/3/1091910783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176005,
-    "geom:area_square_m":2176104009.80853,
+    "geom:area_square_m":2176104010.250241,
     "geom:bbox":"10.260634,0.595172,10.959533,1.034219",
     "geom:latitude":0.838868,
     "geom:longitude":10.624803,
@@ -101,9 +101,10 @@
         "hasc:id":"GA.WN.HK",
         "wd:id":"Q2322905"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1473892579,
-    "wof:geomhash":"56009b751cbf93019a36e732b455c396",
+    "wof:geomhash":"5be503b85ac906d7bf636a8bc8ecbc23",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091910783,
-    "wof:lastmodified":1690914909,
+    "wof:lastmodified":1695886238,
     "wof:name":"Haut Komo",
     "wof:parent_id":85671241,
     "wof:placetype":"county",

--- a/data/421/178/363/421178363.geojson
+++ b/data/421/178/363/421178363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445647,
-    "geom:area_square_m":5510425034.021886,
+    "geom:area_square_m":5510425033.81654,
     "geom:bbox":"9.301776,-0.57221,9.896182,0.66841",
     "geom:latitude":0.071879,
     "geom:longitude":9.581932,
@@ -129,12 +129,13 @@
         "wd:id":"Q2736052",
         "wk:page":"Komo-Mondah Department"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1459009179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"815c50920b15e56b1e379029965dc024",
+    "wof:geomhash":"de76fd5e75a53a98fb71e6f87d8b57b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421178363,
-    "wof:lastmodified":1690914936,
+    "wof:lastmodified":1695886699,
     "wof:name":"Komo Mondah",
     "wof:parent_id":85671235,
     "wof:placetype":"county",

--- a/data/421/181/245/421181245.geojson
+++ b/data/421/181/245/421181245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.60737,
-    "geom:area_square_m":7509253946.809195,
+    "geom:area_square_m":7509253947.423515,
     "geom:bbox":"8.699614,-1.373408,9.961269,-0.273204",
     "geom:latitude":-0.90793,
     "geom:longitude":9.378878,
@@ -137,12 +137,13 @@
         "qs_pg:id":479610,
         "wd:id":"Q538446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1459009289,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"803ce24f5cd7f1cc1998b8701df7a0ff",
+    "wof:geomhash":"ec45d0cd804a66616f0d9bdcfcd521e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421181245,
-    "wof:lastmodified":1690914934,
+    "wof:lastmodified":1695886698,
     "wof:name":"Bendje",
     "wof:parent_id":85671255,
     "wof:placetype":"county",

--- a/data/421/188/215/421188215.geojson
+++ b/data/421/188/215/421188215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.971926,
-    "geom:area_square_m":12017862365.48171,
+    "geom:area_square_m":12017862365.392023,
     "geom:bbox":"11.250468,-0.761599,12.606575,0.632057",
     "geom:latitude":-0.145357,
     "geom:longitude":11.897823,
@@ -156,12 +156,13 @@
         "qs_pg:id":1090778,
         "wd:id":"Q1452178"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GA",
     "wof:created":1459009538,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92a1fcdcb78e114bdd5df2240ec9ca53",
+    "wof:geomhash":"bd56a7cab374f1d8c178fed31334a1ff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421188215,
-    "wof:lastmodified":1690914934,
+    "wof:lastmodified":1695886698,
     "wof:name":"Lope",
     "wof:parent_id":85671237,
     "wof:placetype":"county",

--- a/data/856/324/07/85632407.geojson
+++ b/data/856/324/07/85632407.geojson
@@ -1142,6 +1142,7 @@
         "hasc:id":"GA",
         "icao:code":"TR",
         "ioc:id":"GAB",
+        "iso:code":"GA",
         "itu:id":"GAB",
         "loc:id":"n79063286",
         "m49:code":"266",
@@ -1156,6 +1157,7 @@
         "wk:page":"Gabon",
         "wmo:id":"GO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:country_alpha3":"GAB",
     "wof:geom_alt":[
@@ -1179,7 +1181,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639602,
+    "wof:lastmodified":1695881263,
     "wof:name":"Gabon",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/712/35/85671235.geojson
+++ b/data/856/712/35/85671235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.587162,
-    "geom:area_square_m":19624874844.534447,
+    "geom:area_square_m":19624874843.07328,
     "geom:bbox":"9.301776,-0.57221,10.97361,1.060003",
     "geom:latitude":0.302686,
     "geom:longitude":10.029519,
@@ -329,17 +329,19 @@
         "gn:id":2400682,
         "gp:id":2345449,
         "hasc:id":"GA.ES",
+        "iso:code":"GA-1",
         "iso:id":"GA-1",
         "qs_pg:id":1046583,
         "unlc:id":"GA-1",
         "wd:id":"Q281109",
         "wk:page":"Estuaire Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1d76e6b25216c41bcab410e5a9a52f8",
+    "wof:geomhash":"95e6d26334c4ea598ca0e37dda7ca2df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -354,7 +356,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914901,
+    "wof:lastmodified":1695884839,
     "wof:name":"Estuaire",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/37/85671237.geojson
+++ b/data/856/712/37/85671237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.568578,
-    "geom:area_square_m":44123011247.069817,
+    "geom:area_square_m":44123011246.353806,
     "geom:bbox":"11.250468,-0.761599,14.529043,1.437618",
     "geom:latitude":0.4673,
     "geom:longitude":12.850767,
@@ -315,17 +315,19 @@
         "gn:id":2396926,
         "gp:id":2345454,
         "hasc:id":"GA.OI",
+        "iso:code":"GA-6",
         "iso:id":"GA-6",
         "qs_pg:id":1135045,
         "unlc:id":"GA-6",
         "wd:id":"Q823822",
         "wk:page":"Ogoou\u00e9-Ivindo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fff52ff4b7d503fdf9318f1240d69b48",
+    "wof:geomhash":"9cb10ca1c40e1b84cb2e6f9c2f7636f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -340,7 +342,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914903,
+    "wof:lastmodified":1695884353,
     "wof:name":"Ogoou\u00e9-Ivindo",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/41/85671241.geojson
+++ b/data/856/712/41/85671241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.08404,
-    "geom:area_square_m":38121642609.544334,
+    "geom:area_square_m":38121642608.601418,
     "geom:bbox":"10.260634,0.219184,13.305719,2.318188",
     "geom:latitude":1.39958,
     "geom:longitude":11.941272,
@@ -307,17 +307,19 @@
         "gn:id":2396076,
         "gp:id":2345457,
         "hasc:id":"GA.WN",
+        "iso:code":"GA-9",
         "iso:id":"GA-9",
         "qs_pg:id":91358,
         "unlc:id":"GA-9",
         "wd:id":"Q823800",
         "wk:page":"Woleu-Ntem Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be5e6bd63811995311c83472b8f24e0e",
+    "wof:geomhash":"66c84e17b495ebcc4eeb97674afc6947",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914905,
+    "wof:lastmodified":1695884354,
     "wof:name":"Woleu-Ntem",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/47/85671247.geojson
+++ b/data/856/712/47/85671247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.389792,
-    "geom:area_square_m":17184222073.320553,
+    "geom:area_square_m":17184222072.930164,
     "geom:bbox":"9.549501,-1.263525,11.587622,0.268815",
     "geom:latitude":-0.441914,
     "geom:longitude":10.54869,
@@ -318,17 +318,19 @@
         "gn:id":2397842,
         "gp:id":2345451,
         "hasc:id":"GA.MO",
+        "iso:code":"GA-3",
         "iso:id":"GA-3",
         "qs_pg:id":479601,
         "unlc:id":"GA-3",
         "wd:id":"Q590802",
         "wk:page":"Moyen-Ogoou\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f821990b0734f8a81d823464dde84b9a",
+    "wof:geomhash":"28b4a80917d29ed5fe290571558115e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914907,
+    "wof:lastmodified":1695884355,
     "wof:name":"Moyen-Ogoou\u00e9",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/49/85671249.geojson
+++ b/data/856/712/49/85671249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.183507,
-    "geom:area_square_m":39347026779.528694,
+    "geom:area_square_m":39347026780.016258,
     "geom:bbox":"9.859258,-2.722092,12.518097,-0.383347",
     "geom:latitude":-1.640484,
     "geom:longitude":11.187537,
@@ -313,17 +313,19 @@
         "gn:id":2397466,
         "gp:id":2345452,
         "hasc:id":"GA.NG",
+        "iso:code":"GA-4",
         "iso:id":"GA-4",
         "qs_pg:id":496857,
         "unlc:id":"GA-4",
         "wd:id":"Q823774",
         "wk:page":"Ngouni\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f46a2641fbdd1a096b817764cac6e7e",
+    "wof:geomhash":"057aed781b11225f0080a2f0a284d0e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914906,
+    "wof:lastmodified":1695884354,
     "wof:name":"Ngouni\u00e9",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/51/85671251.geojson
+++ b/data/856/712/51/85671251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.566496,
-    "geom:area_square_m":19341736761.054272,
+    "geom:area_square_m":19341736763.052238,
     "geom:bbox":"10.256784,-3.963731,12.031679,-2.235291",
     "geom:latitude":-3.075906,
     "geom:longitude":11.171825,
@@ -311,17 +311,19 @@
         "gn:id":2397141,
         "gp:id":2345453,
         "hasc:id":"GA.NY",
+        "iso:code":"GA-5",
         "iso:id":"GA-5",
         "qs_pg:id":479603,
         "unlc:id":"GA-5",
         "wd:id":"Q846017",
         "wk:page":"Nyanga Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e1fcd300252fada1156ea6aa7044e70",
+    "wof:geomhash":"c8b69b40fd4bbc83972d1c4942a7c361",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914901,
+    "wof:lastmodified":1695884839,
     "wof:name":"Nyanga",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/55/85671255.geojson
+++ b/data/856/712/55/85671255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.018856,
-    "geom:area_square_m":24950997409.449158,
+    "geom:area_square_m":24950997409.448284,
     "geom:bbox":"8.699614,-3.012308,10.601212,-0.273204",
     "geom:latitude":-1.692769,
     "geom:longitude":9.718414,
@@ -334,16 +334,18 @@
         "gn:id":2396924,
         "gp:id":2345456,
         "hasc:id":"GA.OM",
+        "iso:code":"GA-8",
         "iso:id":"GA-8",
         "qs_pg:id":1135046,
         "unlc:id":"GA-8",
         "wd:id":"Q823751"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d09d3d594be58a4e83161abdfc4ea31a",
+    "wof:geomhash":"f710e6cc7322d75ec04380b8911c4e40",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -358,7 +360,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914904,
+    "wof:lastmodified":1695884504,
     "wof:name":"Ogoou\u00e9-Maritime",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/57/85671257.geojson
+++ b/data/856/712/57/85671257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.784399,
-    "geom:area_square_m":34418152547.049202,
+    "geom:area_square_m":34418152546.931534,
     "geom:bbox":"12.749253,-2.51161,14.52902,0.049898",
     "geom:latitude":-1.337183,
     "geom:longitude":13.732213,
@@ -312,17 +312,19 @@
         "gn:id":2400454,
         "gp:id":2345450,
         "hasc:id":"GA.HO",
+        "iso:code":"GA-2",
         "iso:id":"GA-2",
         "qs_pg:id":229374,
         "unlc:id":"GA-2",
         "wd:id":"Q654438",
         "wk:page":"Haut-Ogoou\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d46e33d42e58facb2292a7f996fc551f",
+    "wof:geomhash":"b015962794beb39355cf8c13c9925d2d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914900,
+    "wof:lastmodified":1695884352,
     "wof:name":"Haut-Ogoou\u00e9",
     "wof:parent_id":85632407,
     "wof:placetype":"region",

--- a/data/856/712/65/85671265.geojson
+++ b/data/856/712/65/85671265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.374853,
-    "geom:area_square_m":29361095588.388332,
+    "geom:area_square_m":29361095692.312531,
     "geom:bbox":"11.497167,-1.926016,13.56558,0.314384",
     "geom:latitude":-0.864232,
     "geom:longitude":12.608146,
@@ -322,17 +322,19 @@
         "gn:id":2396925,
         "gp:id":2345455,
         "hasc:id":"GA.OL",
+        "iso:code":"GA-7",
         "iso:id":"GA-7",
         "qs_pg:id":191321,
         "unlc:id":"GA-7",
         "wd:id":"Q823762",
         "wk:page":"Ogoou\u00e9-Lolo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fcb3bad72c406afc0b4b469c1d20ae63",
+    "wof:geomhash":"bbd051aac750fe8f7e1a145eb8ffc05a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690914902,
+    "wof:lastmodified":1695884353,
     "wof:name":"Ogoou\u00e9-Lolo",
     "wof:parent_id":85632407,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.